### PR TITLE
Fix refund

### DIFF
--- a/src/Message/CommandHandler/RefundPaymentHandler.php
+++ b/src/Message/CommandHandler/RefundPaymentHandler.php
@@ -7,6 +7,7 @@ namespace ThreeBRS\SyliusGoPayPayumPlugin\Message\CommandHandler;
 use Payum\Core\Payum;
 use Sylius\Component\Core\Repository\PaymentRepositoryInterface;
 use ThreeBRS\SyliusGoPayPayumPlugin\Message\Command\RefundPayment;
+use ThreeBRS\SyliusGoPayPayumPlugin\Payum\Request\Factory\CaptureRequestFactoryInterface;
 use ThreeBRS\SyliusGoPayPayumPlugin\Payum\Request\Factory\RefundRequestFactoryInterface;
 
 final class RefundPaymentHandler extends AbstractPayumPaymentHandler
@@ -16,6 +17,7 @@ final class RefundPaymentHandler extends AbstractPayumPaymentHandler
      */
     public function __construct(
         private RefundRequestFactoryInterface $refundRequestFactory,
+        private CaptureRequestFactoryInterface $captureRequestFactory,
         private Payum $payum,
         PaymentRepositoryInterface $paymentRepository,
         array $supportedGateways = ['gopay'],
@@ -41,5 +43,9 @@ final class RefundPaymentHandler extends AbstractPayumPaymentHandler
 
         $refundRequest = $this->refundRequestFactory->createNewWithToken($token);
         $gateway->execute($refundRequest);
+
+        $captureRequest = $this->captureRequestFactory->createNewWithToken($token);
+        // to sync GoPay payment status which is not given by refund request
+        $gateway->execute($captureRequest);
     }
 }

--- a/src/Payum/Action/GoPayAction.php
+++ b/src/Payum/Action/GoPayAction.php
@@ -11,6 +11,7 @@ use Payum\Core\Bridge\Spl\ArrayObject as PayumArrayObject;
 use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Payum;
 use Payum\Core\Reply\HttpRedirect;
+use Payum\Core\Reply\HttpResponse;
 use Payum\Core\Security\TokenInterface;
 use Payum\Core\Storage\IdentityInterface;
 use RuntimeException;
@@ -77,11 +78,12 @@ class GoPayAction implements ApiAwareInterface, ActionInterface
             $this->getAmount($model),
         );
 
-        if (!isset($response->json['errors']) && GoPayApiInterface::REFUNDED === $response->json['state']) {
+        // example of result '{"id":3276091767,"result":"FINISHED"}'
+        if (!isset($response->json['errors']) && GoPayApiInterface::FINISHED === $response->json['result']) {
             $model[self::REFUND_ID] = $response->json['id'];
             $request->setModel($model);
 
-            throw new HttpRedirect($response->json['gw_url']);
+            throw new HttpResponse('OK');
         }
 
         throw new RuntimeException('GoPay error: ' . $response->__toString());

--- a/src/Payum/Action/Partials/UpdateOrderActionTrait.php
+++ b/src/Payum/Action/Partials/UpdateOrderActionTrait.php
@@ -20,28 +20,15 @@ trait UpdateOrderActionTrait
     ): void {
         $response = $gopayApi->retrieve($this->getExternalPaymentId($model));
 
-        if (GoPayApiInterface::PAID === $response->json['state']) {
+        $recognizedStates = [
+            GoPayApiInterface::PAID,
+            GoPayApiInterface::REFUNDED,
+            GoPayApiInterface::CANCELED,
+            GoPayApiInterface::TIMEOUTED,
+            GoPayApiInterface::CREATED,
+        ];
+        if (in_array($response->json['state'], $recognizedStates, true)) {
             $model['gopayStatus'] = $response->json['state'];
-            $request->setModel($model);
-        }
-
-        if (GoPayApiInterface::REFUNDED === $response->json['state']) {
-            $model['gopayStatus'] = $response->json['state'];
-            $request->setModel($model);
-        }
-
-        if (GoPayApiInterface::CANCELED === $response->json['state']) {
-            $model['gopayStatus'] = $response->json['state'];
-            $request->setModel($model);
-        }
-
-        if (GoPayApiInterface::TIMEOUTED === $response->json['state']) {
-            $model['gopayStatus'] = $response->json['state'];
-            $request->setModel($model);
-        }
-
-        if (GoPayApiInterface::CREATED === $response->json['state']) {
-            $model['gopayStatus'] = GoPayApiInterface::CANCELED;
             $request->setModel($model);
         }
     }

--- a/src/Payum/Request/Factory/CancelRequestFactory.php
+++ b/src/Payum/Request/Factory/CancelRequestFactory.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace ThreeBRS\SyliusGoPayPayumPlugin\Payum\Request\Factory;
 
-use Payum\Core\Model\ModelAggregateInterface;
 use Payum\Core\Request\Cancel;
 use Payum\Core\Security\TokenInterface;
 
 final class CancelRequestFactory implements CancelRequestFactoryInterface
 {
-    public function createNewWithToken(TokenInterface $token): ModelAggregateInterface
+    public function createNewWithToken(TokenInterface $token): Cancel
     {
         return new Cancel($token);
     }

--- a/src/Payum/Request/Factory/CancelRequestFactoryInterface.php
+++ b/src/Payum/Request/Factory/CancelRequestFactoryInterface.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace ThreeBRS\SyliusGoPayPayumPlugin\Payum\Request\Factory;
 
-use Payum\Core\Model\ModelAggregateInterface;
+use Payum\Core\Request\Cancel;
 use Payum\Core\Security\TokenInterface;
 
-interface CancelRequestFactoryInterface
+interface CancelRequestFactoryInterface extends ModelAggregateFactoryInterface
 {
-    public function createNewWithToken(TokenInterface $token): ModelAggregateInterface;
+    public function createNewWithToken(TokenInterface $token): Cancel;
 }

--- a/src/Payum/Request/Factory/CaptureRequestFactory.php
+++ b/src/Payum/Request/Factory/CaptureRequestFactory.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace ThreeBRS\SyliusGoPayPayumPlugin\Payum\Request\Factory;
 
-use Payum\Core\Model\ModelAggregateInterface;
 use Payum\Core\Request\Capture;
 use Payum\Core\Security\TokenInterface;
 
-final class CaptureRequestFactory implements ModelAggregateFactoryInterface
+final class CaptureRequestFactory implements CaptureRequestFactoryInterface
 {
-    public function createNewWithToken(TokenInterface $token): ModelAggregateInterface
+    public function createNewWithToken(TokenInterface $token): Capture
     {
         return new Capture($token);
     }

--- a/src/Payum/Request/Factory/CaptureRequestFactoryInterface.php
+++ b/src/Payum/Request/Factory/CaptureRequestFactoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ThreeBRS\SyliusGoPayPayumPlugin\Payum\Request\Factory;
+
+use Payum\Core\Request\Capture;
+use Payum\Core\Security\TokenInterface;
+
+interface CaptureRequestFactoryInterface extends ModelAggregateFactoryInterface
+{
+    public function createNewWithToken(TokenInterface $token): Capture;
+}

--- a/src/Payum/Request/Factory/RefundRequestFactory.php
+++ b/src/Payum/Request/Factory/RefundRequestFactory.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace ThreeBRS\SyliusGoPayPayumPlugin\Payum\Request\Factory;
 
-use Payum\Core\Model\ModelAggregateInterface;
 use Payum\Core\Request\Refund;
 use Payum\Core\Security\TokenInterface;
 
 final class RefundRequestFactory implements RefundRequestFactoryInterface
 {
-    public function createNewWithToken(TokenInterface $token): ModelAggregateInterface
+    public function createNewWithToken(TokenInterface $token): Refund
     {
         return new Refund($token);
     }

--- a/src/Payum/Request/Factory/RefundRequestFactoryInterface.php
+++ b/src/Payum/Request/Factory/RefundRequestFactoryInterface.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace ThreeBRS\SyliusGoPayPayumPlugin\Payum\Request\Factory;
 
-use Payum\Core\Model\ModelAggregateInterface;
+use Payum\Core\Request\Refund;
 use Payum\Core\Security\TokenInterface;
 
-interface RefundRequestFactoryInterface
+interface RefundRequestFactoryInterface extends ModelAggregateFactoryInterface
 {
-    public function createNewWithToken(TokenInterface $token): ModelAggregateInterface;
+    public function createNewWithToken(TokenInterface $token): Refund;
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -78,18 +78,13 @@ services:
         class: ThreeBRS\SyliusGoPayPayumPlugin\Message\CommandHandler\RefundPaymentHandler
         arguments:
             $refundRequestFactory: '@threebrs.gopay_payum.request.factory.refund'
+            $captureRequestFactory: '@threebrs.gopay_payum.request.factory.capture'
             $payum: '@payum'
             $paymentRepository: '@sylius.repository.payment'
             $supportedGateways: [ 'gopay' ]
         tags:
             -   name: messenger.message_handler
                 bus: sylius.command_bus
-
-    threebrs.gopay_payum.request.factory.refund:
-        class: ThreeBRS\SyliusGoPayPayumPlugin\Payum\Request\Factory\RefundRequestFactory
-
-    ThreeBRS\SyliusGoPayPayumPlugin\Payum\Request\Factory\RefundRequestFactoryInterface:
-        alias: threebrs.gopay_payum.request.factory.refund
 
     threebrs.gopay_payum.command.handler.cancel:
         public: true
@@ -102,6 +97,18 @@ services:
         tags:
             -   name: messenger.message_handler
                 bus: sylius.command_bus
+
+    threebrs.gopay_payum.request.factory.capture:
+        class: ThreeBRS\SyliusGoPayPayumPlugin\Payum\Request\Factory\CaptureRequestFactory
+
+    ThreeBRS\SyliusGoPayPayumPlugin\Payum\Request\Factory\CaptureRequestFactoryInterface:
+        alias: threebrs.gopay_payum.request.factory.capture
+
+    threebrs.gopay_payum.request.factory.refund:
+        class: ThreeBRS\SyliusGoPayPayumPlugin\Payum\Request\Factory\RefundRequestFactory
+
+    ThreeBRS\SyliusGoPayPayumPlugin\Payum\Request\Factory\RefundRequestFactoryInterface:
+        alias: threebrs.gopay_payum.request.factory.refund
 
     threebrs.gopay_payum.request.factory.cancel:
         class: ThreeBRS\SyliusGoPayPayumPlugin\Payum\Request\Factory\CancelRequestFactory

--- a/tests/Application/src/Payum/GoPayPaymentsMock.php
+++ b/tests/Application/src/Payum/GoPayPaymentsMock.php
@@ -31,11 +31,27 @@ class GoPayPaymentsMock extends Payments
          * @see \ThreeBRS\SyliusGoPayPayumPlugin\Payum\Action\GoPayAction::processRefund
          * for expected response
          */
-        $data = [
-            'state' => 'REFUNDED',
-            'id' => 123456,
-            'gw_url' => 'https://example.com',
-        ];
+        $data = ['id' => 3276091767, 'result' => 'FINISHED'];
+        $json = json_encode($data);
+        $response = new Response($json);
+        $response->json = $data;
+        $response->statusCode = 200;
+
+        return $response;
+    }
+
+    public function getStatus(
+        $id,
+    ): Response {
+        assert(is_int($id), 'Expected int, got ' . gettype($id));
+
+        $this->lastPaymentId = $id;
+
+        /**
+         * @see \ThreeBRS\SyliusGoPayPayumPlugin\Payum\Action\GoPayAction::processCapture()
+         * for expected response
+         */
+        $data = ['orderId' => 1234, 'externalPaymentId' => 4567, 'state' => 'REFUNDED'];
         $json = json_encode($data);
         $response = new Response($json);
         $response->json = $data;

--- a/tests/Application/src/Payum/GoPayPaymentsMockFactory.php
+++ b/tests/Application/src/Payum/GoPayPaymentsMockFactory.php
@@ -11,7 +11,10 @@ use ThreeBRS\SyliusGoPayPayumPlugin\Payum\GoPayPaymentsFactoryInterface;
 
 class GoPayPaymentsMockFactory implements GoPayPaymentsFactoryInterface
 {
-    private static ?GoPayPaymentsMock $lastPayments = null;
+    /**
+     * @var array<GoPayPaymentsMock>
+     */
+    private static array $lastPayments = [];
 
     public function createPayments(
         string  $goId,
@@ -24,12 +27,15 @@ class GoPayPaymentsMockFactory implements GoPayPaymentsFactoryInterface
         int     $timeout = 30,
     ): Payments {
         $payments = new GoPayPaymentsMock();
-        self::$lastPayments = $payments;
+        self::$lastPayments[] = $payments;
 
         return $payments;
     }
 
-    public function getLastPayments(): ?GoPayPaymentsMock
+    /**
+     * @return array<GoPayPaymentsMock>
+     */
+    public function getLastPayments(): array
     {
         return self::$lastPayments;
     }

--- a/tests/Behat/Context/Setup/OrderContext.php
+++ b/tests/Behat/Context/Setup/OrderContext.php
@@ -46,7 +46,7 @@ class OrderContext implements Context
         Assert::numeric($externalPaymentId);
 
         $lastPayment->setDetails([
-            GoPayAction::ORDER_ID => 123456,
+            GoPayAction::ORDER_ID            => 123456,
             GoPayAction::EXTERNAL_PAYMENT_ID => (int)$externalPaymentId,
         ]);
 
@@ -68,10 +68,15 @@ class OrderContext implements Context
         $lastPayment = $order->getLastPayment();
         Assert::notNull($lastPayment);
 
-        $lastGoPayPaymentsApi = $this->gopayPaymentsFactory->getLastPayments();
-        \assert($lastGoPayPaymentsApi !== null);
-        Assert::same($externalPaymentId, $lastGoPayPaymentsApi->getLastPaymentId());
+        $lastGoPayPaymentApis = $this->gopayPaymentsFactory->getLastPayments();
+        Assert::minCount(
+            $lastGoPayPaymentApis,
+            2,
+            'Expected at least 2 GoPay payment APIs, one for refund, second for capture, got ' . count($lastGoPayPaymentApis),
+        );
+        $lastButOneGoPayPaymentApi = array_slice($lastGoPayPaymentApis, -2, 1)[0];
+        Assert::same($lastButOneGoPayPaymentApi->getLastPaymentId(), $externalPaymentId);
         Assert::notNull($lastPayment->getAmount());
-        Assert::same($lastPayment->getAmount(), $lastGoPayPaymentsApi->getLastAmount());
+        Assert::same($lastButOneGoPayPaymentApi->getLastAmount(), $lastPayment->getAmount());
     }
 }


### PR DESCRIPTION
Refund has different response structure than create payment has, which caused warning.

Also refund does not return status, even that it is obvious. We will defensively call GoPay API again to get it.