### PR TITLE
Add support for cancel as a refund

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,11 @@ install:
 	touch tests/Application/var/log/test.log && chmod 777 tests/Application/var/log/test.log
 
 backend:
-	APP_ENV=test tests/Application/bin/console doctrine:database:drop --force || true
+	APP_ENV=test tests/Application/bin/console doctrine:database:drop --force --if-exists
 	APP_ENV=test tests/Application/bin/console doctrine:database:create --no-interaction
 	APP_ENV=test tests/Application/bin/console doctrine:migrations:migrate --no-interaction
 	APP_ENV=test tests/Application/bin/console doctrine:schema:update --force --complete --no-interaction
 	APP_ENV=test tests/Application/bin/console doctrine:migration:sync-metadata-storage
-	APP_ENV=test tests/Application/bin/console sylius:install --no-interaction
-	APP_ENV=test tests/Application/bin/console sylius:fixtures:load default --no-interaction
 	rm -fr chmod -R 777 tests/Application/var && mkdir -m 777 tests/Application/var
 
 frontend:

--- a/src/Api/GoPayApi.php
+++ b/src/Api/GoPayApi.php
@@ -61,6 +61,11 @@ final class GoPayApi implements GoPayApiInterface
         return $this->gopay->getStatus($paymentId);
     }
 
+    public function voidAuthorization(int $paymentId): Response
+    {
+        return $this->gopay->voidAuthorization($paymentId);
+    }
+
     /**
      * Note: refund requires GoPay token with scope=payment-all
      *

--- a/src/Api/GoPayApiInterface.php
+++ b/src/Api/GoPayApiInterface.php
@@ -12,20 +12,27 @@ interface GoPayApiInterface
 {
     public const CREATED = 'CREATED';
 
+    public const AUTHORIZED = 'AUTHORIZED';
+
     public const PAID = 'PAID';
 
     public const REFUNDED = 'REFUNDED';
 
     public const CANCELED = 'CANCELED';
 
-    public const TIMEOUTED = 'TIMEOUTED';
+    /**
+     * API request timed out
+     *
+     * @noinspection PhpUnused
+     */
+    public const RESULT_TIMEOUTED = 'TIMEOUTED';
 
     /**
      * payment was finalized, for example by a refund
      *
      * @noinspection PhpUnused
      */
-    public const FINISHED = 'FINISHED';
+    public const RESULT_FINISHED = 'FINISHED';
 
     public function authorize(
         string $goId,
@@ -44,6 +51,8 @@ interface GoPayApiInterface
     public function create(array $order): Response;
 
     public function retrieve(int $paymentId): Response;
+
+    public function voidAuthorization(int $paymentId): Response;
 
     public function refund(
         int $paymentId,

--- a/src/Payum/Action/CancelAction.php
+++ b/src/Payum/Action/CancelAction.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ThreeBRS\SyliusGoPayPayumPlugin\Payum\Action;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\ApiAwareInterface;
+use Payum\Core\Bridge\Spl\ArrayObject as PayumArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\GatewayAwareInterface;
+use Payum\Core\GatewayAwareTrait;
+use Payum\Core\Request\Cancel;
+use Payum\Core\Security\TokenInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use ThreeBRS\SyliusGoPayPayumPlugin\Api\GoPayApiInterface;
+use ThreeBRS\SyliusGoPayPayumPlugin\Payum\Action\Partials\AuthorizeGoPayActionTrait;
+use ThreeBRS\SyliusGoPayPayumPlugin\Payum\Action\Partials\ParseFallbackLocaleCodeTrait;
+use ThreeBRS\SyliusGoPayPayumPlugin\Payum\Request\GoPayPayumRequest;
+
+final class CancelAction implements
+    ActionInterface,
+    GatewayAwareInterface,
+    ApiAwareInterface
+{
+    use GatewayAwareTrait;
+    use AuthorizeGoPayActionTrait;
+    use ParseFallbackLocaleCodeTrait;
+
+    public const CANCEL_ACTION = 'cancel';
+
+    public function __construct(
+        private GoPayApiInterface $goPayApi,
+    ) {
+    }
+
+    /**
+     * De facto a callback processed on @see Cancel request.
+     */
+    public function execute($request): void
+    {
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        \assert($request instanceof Cancel);
+        $model = PayumArrayObject::ensureArrayObject($request->getModel());
+
+        $payment = $request->getFirstModel();
+        \assert($payment instanceof PaymentInterface);
+        $model['amount'] = $payment->getAmount();
+
+        $localeCode = $payment->getOrder()?->getLocaleCode();
+        \assert($localeCode !== null);
+        $model['locale'] = $this->parseFallbackLocaleCode($localeCode);
+
+        $this->authorizeGoPayAction($model, $this->goPayApi);
+
+        $token = $request->getToken();
+        \assert($token instanceof TokenInterface);
+        $this->gateway->execute(
+            request: $this->createRequest($token, $model),
+            catchReply: true, // do not want to throw a "redirect-to-landing-page" exception
+        );
+    }
+
+    public function supports($request): bool
+    {
+        return
+            $request instanceof Cancel &&
+            $request->getModel() instanceof \ArrayAccess;
+    }
+
+    private function createRequest(
+        TokenInterface $token,
+        PayumArrayObject $model,
+    ): GoPayPayumRequest {
+        $goPayPayumRequest = new GoPayPayumRequest($token);
+        $goPayPayumRequest->setModel($model);
+        $goPayPayumRequest->setTriggeringAction(self::CANCEL_ACTION);
+
+        return $goPayPayumRequest;
+    }
+}

--- a/src/Payum/Action/Exception/PaymentCanNotBeCanceledException.php
+++ b/src/Payum/Action/Exception/PaymentCanNotBeCanceledException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ThreeBRS\SyliusGoPayPayumPlugin\Payum\Action\Exception;
+
+class PaymentCanNotBeCanceledException extends \RuntimeException
+{
+    public function __construct(
+        string $message = '',
+        int $code = 0,
+        ?\Throwable $previous = null,
+        private ?string $goPayStatus = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getGoPayStatus(): ?string
+    {
+        return $this->goPayStatus;
+    }
+}

--- a/src/Payum/Action/Partials/UpdateOrderActionTrait.php
+++ b/src/Payum/Action/Partials/UpdateOrderActionTrait.php
@@ -21,14 +21,14 @@ trait UpdateOrderActionTrait
         $response = $gopayApi->retrieve($this->getExternalPaymentId($model));
 
         $recognizedStates = [
+            GoPayApiInterface::CREATED,
+            GoPayApiInterface::AUTHORIZED,
             GoPayApiInterface::PAID,
             GoPayApiInterface::REFUNDED,
             GoPayApiInterface::CANCELED,
-            GoPayApiInterface::TIMEOUTED,
-            GoPayApiInterface::CREATED,
         ];
         if (in_array($response->json['state'], $recognizedStates, true)) {
-            $model['gopayStatus'] = $response->json['state'];
+            $model[GoPayAction::GOPAY_STATUS] = $response->json['state'];
             $request->setModel($model);
         }
     }

--- a/src/Payum/Action/StatusAction.php
+++ b/src/Payum/Action/StatusAction.php
@@ -20,7 +20,7 @@ class StatusAction implements ActionInterface
         assert($request instanceof GetStatusInterface);
 
         $model = ArrayObject::ensureArrayObject($request->getModel());
-        $status = $model['gopayStatus']
+        $status = $model[GoPayAction::GOPAY_STATUS]
             ?? null;
 
         if ((null === $status || GoPayApiInterface::CREATED === $status) && !isset($model['orderId'])) {
@@ -36,12 +36,6 @@ class StatusAction implements ActionInterface
         }
 
         if (GoPayApiInterface::CANCELED === $status) {
-            $request->markCanceled();
-
-            return;
-        }
-
-        if (GoPayApiInterface::TIMEOUTED === $status) {
             $request->markCanceled();
 
             return;

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -58,6 +58,13 @@ services:
         tags:
             - { name: 'payum.action', factory: 'gopay' }
 
+    threebrs.gopay_payum.action.cancel:
+        class: ThreeBRS\SyliusGoPayPayumPlugin\Payum\Action\CancelAction
+        arguments:
+            - '@threebrs.gopay_payum.api'
+        tags:
+            - { name: 'payum.action', factory: 'gopay' }
+
     threebrs.gopay_payum.action.status:
         class: ThreeBRS\SyliusGoPayPayumPlugin\Payum\Action\StatusAction
         tags:
@@ -93,6 +100,7 @@ services:
             $cancelRequestFactory: '@threebrs.gopay_payum.request.factory.cancel'
             $payum: '@payum'
             $paymentRepository: '@sylius.repository.payment'
+            $logger: '@logger'
             $supportedGateways: [ 'gopay' ]
         tags:
             -   name: messenger.message_handler

--- a/src/StateMachine/CancelOrderProcessor.php
+++ b/src/StateMachine/CancelOrderProcessor.php
@@ -16,8 +16,10 @@ final class CancelOrderProcessor implements PaymentStateProcessorInterface
     ) {
     }
 
-    public function __invoke(PaymentInterface $payment, string $fromState): void
-    {
+    public function __invoke(
+        PaymentInterface $payment,
+        string $fromState,
+    ): void {
         if (!in_array($fromState, [PaymentInterface::STATE_NEW, PaymentInterface::STATE_AUTHORIZED], true)) {
             return;
         }
@@ -25,6 +27,7 @@ final class CancelOrderProcessor implements PaymentStateProcessorInterface
         /** @var int|null $paymentId */
         $paymentId = $payment->getId();
         Assert::notNull($paymentId, 'Missing ID on payment object');
+
         $this->commandBus->dispatch(new CancelPayment($paymentId));
     }
 }


### PR DESCRIPTION
When the `PaymentTransitions::TRANSITION_CANCEL` is executed on a payment, then cancel payment via GoPay is expected.

We will simulate that by calling refund and if it fails, then we will ask GoPay if the payment is already canceled and if it is, then job is done.